### PR TITLE
Coverage Increase

### DIFF
--- a/tests/test_neurovis.py
+++ b/tests/test_neurovis.py
@@ -1,5 +1,5 @@
-import matplotlib
-matplotlib.use('Agg')
+import matplotlib.pyplot as p
+p.switch_backend('Agg')
 from spykes.neurovis import NeuroVis
 from nose.tools import assert_true, assert_equal, assert_raises
 import numpy as np

--- a/tests/test_neurovis.py
+++ b/tests/test_neurovis.py
@@ -1,3 +1,5 @@
+import matplotlib
+matplotlib.use('Agg')
 from spykes.neurovis import NeuroVis
 from nose.tools import assert_true, assert_equal, assert_raises
 import numpy as np
@@ -37,7 +39,7 @@ def test_neurovis():
     df[condition_bool] = df[condition_num] < 0.5
 
     raster = neuron.get_raster(event=event, conditions=condition_bool, df=df, 
-        plot=False, binsize=binsize, window=window)
+        plot=True, binsize=binsize, window=window)
 
     assert_equal(raster['event'], event)
     assert_equal(raster['conditions'], condition_bool)
@@ -56,7 +58,7 @@ def test_neurovis():
     assert_equal(total_trials, num_trials)
 
     psth = neuron.get_psth(event=event, conditions=condition_bool, df=df, 
-        plot=False, binsize=binsize, window=window)
+        plot=True, binsize=binsize, window=window)
 
     assert_equal(psth['window'], window)
     assert_equal(psth['binsize'], binsize)

--- a/tests/test_popvis.py
+++ b/tests/test_popvis.py
@@ -1,3 +1,5 @@
+import matplotlib.pyplot as p
+p.switch_backend('Agg')
 from spykes.popvis import PopVis
 from spykes.neurovis import NeuroVis
 from nose.tools import assert_true, assert_equal, assert_raises
@@ -43,7 +45,7 @@ def test_popvis():
 
 
     all_psth = pop.get_all_psth(event=event, conditions=condition_bool, df=df, 
-        plot=False, binsize=binsize, window=window)
+        plot=True, binsize=binsize, window=window)
 
     assert_equal(all_psth['window'], window)
     assert_equal(all_psth['binsize'], binsize)

--- a/tests/test_strf.py
+++ b/tests/test_strf.py
@@ -1,3 +1,5 @@
+import matplotlib.pyplot as p
+p.switch_backend('Agg')
 from spykes.strf import STRF
 from nose.tools import assert_equal
 from mock import patch
@@ -18,6 +20,9 @@ def test_strf(mock_show):
     # Design a spatial basis
     spatial_basis = strf_.make_gaussian_basis()
     assert_equal(len(spatial_basis), n_spatial_basis)
+
+    # Visualize spatial basis
+    strf_.visualize_gaussian_basis(spatial_basis)
 
     # Design temporal basis
     time_points = np.linspace(-100., 100., 10.)


### PR DESCRIPTION
Ironically, I found the answer to suppress the output while trying to solve a problem with the sphinx-gallery.

We need to switch the backend of `matplotlib` to `agg` in order to generate an image but suppress output. There was some issue because we import matplotlib in all the classes.

Thus, each of the test files that plots must re-import matplotlib and change the backend

See: http://stackoverflow.com/questions/3285193/how-to-switch-backends-in-matplotlib-python

Note: As the StackOverflow post says, the feature is experimental. Thus, not sure if this is a temporary or permanent fix. But, now coverage is 85-90%