### PR TITLE
Changed imports to use absolute_import

### DIFF
--- a/spykes/__init__.py
+++ b/spykes/__init__.py
@@ -1,6 +1,14 @@
+from __future__ import absolute_import
+
 from .neurovis import NeuroVis
 from .neuropop import NeuroPop
 from .popvis import PopVis
 from .strf import STRF
-from .utils import slow_exp, grad_slow_exp, log_likelihood, circ_corr
+from .utils import (
+    slow_exp,
+    grad_slow_exp,
+    log_likelihood,
+    circ_corr,
+)
+
 __version__ = '0.1.dev'

--- a/spykes/datasets.py
+++ b/spykes/datasets.py
@@ -137,15 +137,15 @@ def load_reaching_data(dpath='~/spykes_data/reaching/'):
 
     # Import is performed here so that deepdish is not required for all of
     # the "datasets" functions.
-    try:
-        import deepdish
-    except ImportError:
-        raise RuntimeError('deepdish is required to load the reaching dataset.')
+    import deepdish
 
     if not os.path.exists(dpath):
         os.makedirs(dpath)
 
-    url = 'https://northwestern.app.box.com/index.php?rm=box_download_shared_file&shared_name=xbe3xpnv6gpx0c1mrfhb1bal4cyei5n8&file_id=f_71457089609' # noqa
+    url = ('https://northwestern.app.box.com/index.php?'
+           'rm=box_download_shared_file&'
+           'shared_name=xbe3xpnv6gpx0c1mrfhb1bal4cyei5n8&'
+           'file_id=f_71457089609')
 
     fname = os.path.join(dpath, 'reaching_dataset.h5')
 

--- a/spykes/datasets.py
+++ b/spykes/datasets.py
@@ -6,7 +6,6 @@ import os
 import urllib
 import scipy.io
 import numpy as np
-import deepdish as dd
 
 
 def load_reward_data(dpath='~/spykes_data/reward/'):
@@ -136,6 +135,13 @@ def load_reaching_data(dpath='~/spykes_data/reaching/'):
     deep dish loaded dataset
     """
 
+    # Import is performed here so that deepdish is not required for all of
+    # the "datasets" functions.
+    try:
+        import deepdish
+    except ImportError:
+        raise RuntimeError('deepdish is required to load the reaching dataset.')
+
     if not os.path.exists(dpath):
         os.makedirs(dpath)
 
@@ -146,7 +152,7 @@ def load_reaching_data(dpath='~/spykes_data/reaching/'):
     if not os.path.exists(fname):
         urllib.urlretrieve(url, fname)
 
-    return dd.io.load(fname)
+    return deepdish.io.load(fname)
 
 
 def _load_file(fname):

--- a/spykes/neuropop.py
+++ b/spykes/neuropop.py
@@ -1,6 +1,9 @@
+from __future__ import absolute_import
+
 import numpy as np
 from copy import deepcopy
 import matplotlib.pyplot as plt
+
 from . import utils
 
 

--- a/spykes/neurovis.py
+++ b/spykes/neurovis.py
@@ -1,5 +1,8 @@
+from __future__ import absolute_import
+
 import numpy as np
 import matplotlib.pyplot as plt
+
 from . import utils
 
 

--- a/spykes/popvis.py
+++ b/spykes/popvis.py
@@ -1,10 +1,12 @@
+from __future__ import absolute_import
+
 import numpy as np
 import matplotlib.pyplot as plt
 import copy
 
 from fractions import gcd
 
-from spykes.neurovis import NeuroVis
+from .neurovis import NeuroVis
 from . import utils
 
 


### PR DESCRIPTION
Updated a few files to use `absolute_import`, partially to be cleaner and more compatible with Python 3 - see [here](https://www.python.org/dev/peps/pep-0328/).

Also made a small change in `spykes/datasets.py` to make deepdish a local import - this way doing `import spykes` won't require having deepdish installed.

(This is a small PR to get the hang of stuff)

Testing passes for Python 2.7 and 3.6, except for a compatibility warning with scikit:

```bash
================================== test session starts ==================================
platform darwin -- Python 2.7.10, pytest-3.2.3, py-1.4.34, pluggy-0.4.0
rootdir: /Users/judgingmoloch/workspace/spykes, inifile:
collected 4 items                                                                        

tests/test_neuropop.py .
tests/test_neurovis.py .
tests/test_popvis.py .
tests/test_strf.py .

=================================== warnings summary ====================================
tests/test_neuropop.py::test_neuropop
  /Users/judgingmoloch/workspace/spykes/venvs/p27/lib/python2.7/site-packages/sklearn/cross_validation.py:41: DeprecationWarning: This module was deprecated in version 0.18 in favor of the model_selection module into which all the refactored classes and functions are moved. Also note that the interface of the new CV iterators are different from that of this module. This module will be removed in 0.20.
    "This module will be removed in 0.20.", DeprecationWarning)

-- Docs: http://doc.pytest.org/en/latest/warnings.html
========================= 4 passed, 1 warnings in 40.50 seconds =========================
```

System:

```bash
>>> pip freeze
backports.functools-lru-cache==1.4
cycler==0.10.0
matplotlib==2.1.0
nose==1.3.7
numpy==1.13.3
pandas==0.20.3
py==1.4.34
pyparsing==2.2.0
pytest==3.2.3
python-dateutil==2.6.1
pytz==2017.2
scikit-learn==0.19.0
scipy==0.19.1
six==1.11.0
sklearn==0.0
-e git+git@github.com:codekansas/spykes.git@227b964eb3e49d8c8c044fab3f56d3b48a3a967b#egg=spykes
subprocess32==3.2.7
```
