### PR TITLE
TensorFlow implementation of GLM and GVM

### DIFF
--- a/doc/api/ml.rst
+++ b/doc/api/ml.rst
@@ -24,3 +24,11 @@ This module makes use of Tensorflow. Make sure your system is configured correct
 .. automodule:: spykes.ml.tensorflow.sparse_filtering
   :members:
 
+Poisson Layers
+~~~~~~~~~~~~~~
+
+This module provides a TensorFlow implementation of the Poisson estimators used in the NeuroPop modules.
+
+.. automodule:: spykes.ml.tensorflow.poisson_models
+  :members:
+

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ if __name__ == "__main__":
                 'deepdish',
                 'image',
                 'tensorflow>=1.4.0',
+                'h5py',
             ],
             'ml': [
                 'tensorflow>=1.4.0',

--- a/spykes/io/datasets.py
+++ b/spykes/io/datasets.py
@@ -253,3 +253,94 @@ def load_reaching_data(dir_name='reaching'):
 
     data = deepdish.io.load(fpath)
     return data
+
+
+def load_reaching_xy(event='goCueTime', feature='endpointOfReach', neuron='M1',
+                     window_min=0., window_max=500., threshold=10.,
+                     dir_name='reaching'):
+    '''Extracts the reach direction and M1 spikes from the reaching dataset.
+
+    Args:
+        event (str): Event to which to align each trial; :data:`goCueTime`,
+            :data:`targetOnTime` or :data:`rewardTime`.
+        feature (str): The feature to get; :data:`endpointOfReach` or
+            :data:`reward`.
+        neuron (str): The neuron response to use, either :data:`M1` or
+            :data:`PMd`.
+        window_min (double): The lower window value around the align queue to
+            get spike counts, in milliseconds.
+        window_max (double): The upper window value around the align queue to
+            get spike counts, in milliseconds.
+        threshold (double): The threshold for selecting high-firing neurons,
+            representing the minimum firing rate in Hz.
+        dir_name (str): Specifies the directory to which the data files
+            should be downloaded. This is concatenated with the user-set
+            data directory.
+
+    Returns:
+        tuple: The :data:`x` and :data:`y` features of the dataset.
+
+        * :data:`x`: Array with shape :data:`(num_samples, num_features)`
+        * :data:`y`: Array with shape :data:`(num_samples, num_neurons)`
+    '''
+
+    # Loads the formatted data, if it has already been processed.
+    fname = '{}.npz'.format('_'.join('{}'.format(i) for i in [
+        event, feature, neuron, window_min, window_max, threshold
+    ]))
+    fpath = os.path.join(config.get_data_directory(), dir_name, fname)
+    if os.path.exists(fpath):
+        with open(fpath, 'rb') as f:
+            data = np.load(f)
+            return data['x'], data['y']
+
+    # Loads the reaching data normally.
+    reaching_data = load_reaching_data(dir_name)
+
+    events = list(reaching_data['events'].keys())
+    features = list(reaching_data['features'].keys())
+
+    # Checks the input arguments, throwing helpful error messages if needed.
+    if event not in events:
+        raise ValueError('Invalid align event: "{}". Must be one of {}.'
+                         .format(event, events))
+    if feature not in features:
+        raise ValueError('Invalid feature: "{}". Must be one of {}.'
+                         .format(feature, features))
+    if neuron not in ('M1', 'PMd'):
+        raise ValueError('Invalid neuron type: "{}". Must be either "M1" or '
+                         '"PMd".'.format(neuron))
+
+    neuron_key = 'neurons_{}'.format(neuron)
+    spike_times = np.asarray([
+        np.squeeze(np.sort(s)) for s in reaching_data[neuron_key]
+    ])
+    spike_freqs = np.asarray([len(t) / (t[-1] - t[0]) for t in spike_times])
+
+    # Applies the cutoff threshold.
+    thresh_idxs = np.where(spike_freqs > threshold)[0]
+    spike_times = spike_times[thresh_idxs]
+    spike_freqs = spike_freqs[thresh_idxs]
+
+    # Gets the reach angle, in radians.
+    x = reaching_data['features'][feature] * np.pi / 180.0
+    x = np.arctan2(np.sin(x), np.cos(x))
+
+    # Gets the spike responses.
+    event_data = reaching_data['events'][event]
+
+    def _get_spikecounts(n):
+        return np.asarray([
+            np.sum(np.all((
+                n >= e + 1e-3 * window_min,
+                n <= e + 1e-3 * window_max,
+            ), axis=0))
+            for e in event_data
+        ])
+    y = np.stack([_get_spikecounts(n) for n in spike_times]).transpose(1, 0)
+
+    # Saves the dataset after processing it.
+    with open(fpath, 'wb') as f:
+        np.savez(f, x=x, y=y)
+
+    return x, y

--- a/spykes/ml/neuropop.py
+++ b/spykes/ml/neuropop.py
@@ -20,15 +20,17 @@ class NeuroPop(object):
 
     .. math::
 
-        f(x) = b_ + g_ * exp(k_ * cos(x - mu_))
-        f(x) = b_ + g_ * exp(k1_ * cos(x) + k2_ * sin(x))
+        f(x) = b + g * exp(k * cos(x - mu))
+
+        f(x) = b + g * exp(k1 * cos(x) + k2 * sin(x))
 
     The Poisson generalized linear model is defined by
 
     .. math::
 
-        f(x) = exp(k0_ + k_ * cos(x - mu_))
-        f(x) = exp(k0_ + k1_ * cos(x) + k2_ * sin(x))
+        f(x) = exp(k0 + k * cos(x - mu))
+
+        f(x) = exp(k0 + k1 * cos(x) + k2 * sin(x))
 
     Args:
         tunemodel (str): Can be either :data:`gvm`, the Generalized von Mises

--- a/spykes/ml/tensorflow/poisson_models.py
+++ b/spykes/ml/tensorflow/poisson_models.py
@@ -1,0 +1,138 @@
+from math import pi as PI
+
+import tensorflow as tf
+from tensorflow import keras as ks
+
+
+class PoissonLayer(ks.layers.Layer):
+    '''Defines a TensorFlow implementation of the NeuroPop layers.
+
+    Two types of models are available. `The Generalized von Mises model by
+    Amirikan & Georgopulos (2000) <http://brain.umn.edu/pdfs/BA118.pdf>`_ is
+    defined by
+
+    .. math::
+
+        f(x) = b + g * exp(k * cos(x - mu))
+
+        f(x) = b + g * exp(k1 * cos(x) + k2 * sin(x))
+
+    The Poisson generalized linear model is defined by
+
+    .. math::
+
+        f(x) = exp(k0 + k * cos(x - mu))
+
+        f(x) = exp(k0 + k1 * cos(x) + k2 * sin(x))
+
+
+    Args:
+        model_type (str): Can be either :data:`gvm`, the Generalized von Mises
+            model, or :data:`glm`, the Poisson generalized linear model.
+        num_neurons (int): Number of neurons in the population (being inferred
+            from the input features).
+        num_features (int): Number of input features. Convenience parameter for
+            for setting the input shape.
+        mu_initializer (Keras initializer): The initializer for the :data:`mu`.
+        k_initializer (Keras initializer): The initializer for the :data:`k`.
+        g_initializer (Keras initializer): The initializer for the :data:`g`.
+            If :data:`model_type` is :data:`glm`, this is ignored.
+        b_initializer (Keras initializer): The initializer for the :data:`b`.
+            If :data:`model_type` is :data:`glm`, this is ignored.
+        k0_initializer (Keras initializer): The initializer for the :data:`k0`.
+            If :data:`model_type` is :data:`gvm`, this is ignored.
+    '''
+
+    def __init__(self,
+                 model_type,
+                 num_neurons,
+                 num_features=None,
+                 mu_initializer=ks.initializers.RandomUniform(-PI, PI),
+                 k_initializer=ks.initializers.RandomNormal(stddev=.2),
+                 g_initializer=ks.initializers.RandomNormal(stddev=.05),
+                 b_initializer=ks.initializers.RandomNormal(stddev=.1),
+                 k0_initializer=ks.initializers.RandomNormal(stddev=.01),
+                 **kwargs):
+        if num_features is not None:
+            kwargs['input_shape'] = (num_features,)
+        super(PoissonLayer, self).__init__(**kwargs)
+        self.model_type = model_type.lower()
+        if self.model_type not in ('gvm', 'glm'):
+            raise ValueError('Invalid model type: "{}" Must be either "gvm" '
+                             '(generalised Von Mises model) or "glm" '
+                             '(generalized linear model)'.format(model_type))
+
+        self.num_neurons = num_neurons
+        self.mu_initializer = ks.initializers.get(mu_initializer)
+        self.g_initializer = ks.initializers.get(g_initializer)
+        self.b_initializer = ks.initializers.get(b_initializer)
+        self.k_initializer = ks.initializers.get(k_initializer)
+        self.k0_initializer = ks.initializers.get(k0_initializer)
+
+    def build(self, input_shape):
+        assert len(input_shape) == 2
+        input_dim = input_shape[-1]
+
+        self.mu = self.add_weight(
+            shape=(input_dim, self.num_neurons),
+            initializer=self.mu_initializer,
+            name='mu',
+        )
+        self.k1 = self.add_weight(
+            shape=(input_dim, self.num_neurons),
+            initializer=self.k_initializer,
+            name='k1',
+        )
+        self.k2 = self.add_weight(
+            shape=(input_dim, self.num_neurons),
+            initializer=self.k_initializer,
+            name='k2',
+        )
+
+        # Adds generalized Von Mises parameters.
+        if self.model_type == 'gvm':
+            self.g = self.add_weight(
+                shape=(1, input_dim),
+                initializer=self.g_initializer,
+                name='g',
+            )
+            self.b = self.add_weight(
+                shape=(1, input_dim),
+                initializer=self.b_initializer,
+                name='b',
+            )
+
+        # Adds generalized linear model parameters.
+        if self.model_type == 'glm':
+            self.k0 = self.add_weight(
+                shape=(1, input_dim),
+                initializer=self.k_initializer,
+                name='k0',
+            )
+
+    def call(self, inputs):
+        k1 = tf.matmul(tf.cos(inputs), self.k1 * tf.cos(self.mu))
+        k2 = tf.matmul(tf.sin(inputs), self.k2 * tf.sin(self.mu))
+
+        # Defines the two model formulations: "glm" vs "gvm".
+        if self.model_type == 'glm':
+            return tf.exp(k1 + k2 + self.k0)
+        else:
+            return tf.nn.softplus(self.b) + self.g * tf.exp(k1 + k2)
+
+    def get_config(self):
+        config = {
+            'model_type': self.model_type,
+            'mu_initializer': ks.initializers.serialize(self.mu_initializer),
+            'g_initializer': ks.initializers.serialize(self.g_initializer),
+            'b_initializer': ks.initializers.serialize(self.b_initializer),
+            'k_initializer': ks.initializers.serialize(self.k_initializer),
+            'k0_initializer': ks.initializers.serialize(self.k0_initializer),
+        }
+        base_config = super(PoissonLayer, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+    def compute_output_shape(self, input_shape):
+        output_shape = list(input_shape)
+        output_shape[-1] = self.num_neurons
+        return tuple(output_shape)

--- a/spykes/plot/neurovis.py
+++ b/spykes/plot/neurovis.py
@@ -371,8 +371,6 @@ class NeuroVis(object):
         '''
         events = df[event].values
         spiketimes = self.spiketimes
-        spikecounts = np.zeros(events.shape)
-
         spikecounts = np.asarray([
             np.sum(np.all((
                 spiketimes >= e + 1e-3 * window[0],

--- a/tests/ml/tensorflow/test_poisson_models.py
+++ b/tests/ml/tensorflow/test_poisson_models.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import
+
+import os
+import uuid
+
+import numpy as np
+from nose.tools import (
+    assert_raises,
+    assert_false,
+)
+
+from tempfile import TemporaryFile
+
+import tensorflow as tf
+from tensorflow import keras as ks
+
+from spykes.ml.tensorflow.poisson_models import PoissonLayer
+from spykes.io.datasets import load_reaching_xy
+
+
+def _build_model(model_type, num_features, num_neurons):
+    i = ks.layers.Input(shape=(num_features,))
+    x = PoissonLayer(model_type, num_neurons)(i)
+    model = ks.models.Model(inputs=i, outputs=x)
+    model.compile(optimizer='sgd', loss='poisson')
+    return model
+
+
+def test_poisson_layer():
+    with assert_raises(ValueError):
+        PoissonLayer('invalid_type', 1)
+
+    with assert_raises(AssertionError):
+        i = ks.layers.Input(shape=(1,2))
+        x = PoissonLayer('glm', 3, num_features=2)(i)
+
+    # Loads the reaching dataset (with default parameters).
+    x, y = load_reaching_xy()
+    num_features, num_neurons = x.shape[1], y.shape[1]
+
+    for model_type in ('gvm', 'glm'):
+        model = _build_model(model_type, num_features, num_neurons)
+        p = model.predict(x)
+        h = model.fit(x, y, epochs=1)  # , verbose=0)
+        assert_false(np.any(np.isnan(h.history['loss'])))
+
+        if model_type == 'gvm':
+            tmploc = '/tmp/{}'.format(uuid.uuid4)
+            model.save(tmploc)
+            os.remove(tmploc)


### PR DESCRIPTION
- Added implementations of the GLM and GVM models, as TensorFlow layers
- Added a convenience function `load_reaching_xy` for loading the `x` and `y` reaching data as spike times
- It would probably be a good idea to add an example of how to use this, eventually