### PR TITLE
Performance bump in PSTH

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
             'matplotlib',
             'pandas',
             'requests',
-            'numba==0.48.0',
+            'numba',
             'joblib'
         ],
         extras_require={

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,8 @@ if __name__ == "__main__":
             'matplotlib',
             'pandas',
             'requests',
+            'numba',
+            'joblib'
         ],
         extras_require={
             'deepdish': ['deepdish'],

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
             'matplotlib',
             'pandas',
             'requests',
-            'numba',
+            'numba==0.48.0',
             'joblib'
         ],
         extras_require={

--- a/spykes/plot/neurovis.py
+++ b/spykes/plot/neurovis.py
@@ -56,11 +56,11 @@ class NeuroVis(object):
             raster for each unique entry of :data:`df['conditions']`.
         '''
 
-        @numba.njit(nopython=True)
+        @numba.njit()
         def searchsorted_jit(_a, _v):
             return np.searchsorted(_a, _v)
 
-        @numba.njit(nopython=True)
+        @numba.njit()
         def numba_histogram(v, b):
             return np.histogram(v, b)
 

--- a/spykes/plot/popvis.py
+++ b/spykes/plot/popvis.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import warnings
+
 import numpy as np
 import matplotlib.pyplot as plt
 import copy
@@ -96,7 +98,7 @@ class PopVis(object):
                     conditions=conditions,
                     window=window,
                     binsize=binsize,
-                    plot=False)  for neuron in self.neuron_list]
+                    plot=False) for neuron in self.neuron_list]
 
         for psth in psths:
             for cond_id in np.sort(list(psth['data'].keys())):
@@ -215,7 +217,7 @@ class PopVis(object):
                              conditions=None, cond_id=None, window=[-100, 500],
                              binsize=10, conditions_names=None,
                              event_name='event_onset', ylim=None,
-                             colors=DEFAULT_POPULATION_COLORS, show=False):
+                             colors=DEFAULT_POPULATION_COLORS, show=True):
         '''Plots population PSTH's.
 
         This involves two steps. First, it normalizes each neuron's PSTH across
@@ -327,6 +329,6 @@ class PopVis(object):
         elif normalize is None:
             norm_factors = np.ones([data.shape[0], 1])
         else:
-            raise ValueError('Invalid norm factors: {}'.format(norm_factors))
+            raise ValueError('Invalid norm factors: {}'.format(normalize))
 
         return data / norm_factors

--- a/spykes/plot/popvis.py
+++ b/spykes/plot/popvis.py
@@ -8,9 +8,10 @@ import numpy as np
 import matplotlib.pyplot as plt
 import copy
 from collections import defaultdict
-
-from fractions import gcd
-
+try:
+    from fractions import gcd
+except ImportError:
+    from math import gcd
 from .neurovis import NeuroVis
 from .. import utils
 from ..config import DEFAULT_POPULATION_COLORS

--- a/spykes/plot/popvis.py
+++ b/spykes/plot/popvis.py
@@ -62,6 +62,7 @@ class PopVis(object):
                 Default are the unique values in :data:`df['conditions']`.
             plot (bool): If set, automatically plot; otherwise, don't.
             colors (list): List of colors for heatmap (only if plot is True).
+            use_parallel (bool): If set, parallelize PSTH computation
 
         Returns:
             dict: With keys :data:`event`, :data:`conditions`, :data:`binsize`,

--- a/spykes/plot/popvis.py
+++ b/spykes/plot/popvis.py
@@ -103,7 +103,10 @@ class PopVis(object):
 
         for psth in psths:
             for cond_id in np.sort(list(psth['data'].keys())):
-                all_psth['data'][cond_id].append(psth['data'][cond_id]['mean'])
+                all_psth['data'][cond_id].append(
+                    psth['data'][cond_id]['mean']
+                )
+
 
         for cond_id in np.sort(list(all_psth['data'].keys())):
             all_psth['data'][cond_id] = np.stack(all_psth['data'][cond_id])

--- a/spykes/plot/popvis.py
+++ b/spykes/plot/popvis.py
@@ -79,7 +79,7 @@ class PopVis(object):
             'conditions': conditions,
             'data': defaultdict(list),
         }
-        
+
         if use_parallel:
             from joblib import Parallel, delayed
             psths = Parallel(n_jobs=-1)(delayed(neuron.get_psth)(

--- a/tests/ml/test_strf.py
+++ b/tests/ml/test_strf.py
@@ -33,7 +33,7 @@ def test_strf():
     strf_.visualize_gaussian_basis(spatial_basis)
 
     # Design temporal basis
-    time_points = np.linspace(-100., 100., 10.)
+    time_points = np.linspace(-100., 100., 10)
     centers = [-75., -50., -25., 0, 25., 50., 75.]
     width = 10.
     temporal_basis = strf_.make_raised_cosine_temporal_basis(

--- a/tests/plot/test_popvis.py
+++ b/tests/plot/test_popvis.py
@@ -53,8 +53,115 @@ def test_popvis():
     df[condition_num] = np.random.rand(num_trials)
     df[condition_bool] = df[condition_num] < 0.5
 
+    df = pd.DataFrame()
+
+    event = 'anotherRealCueTime'
+    condition_num = 'responseNum'
+    condition_bool = 'responseBool'
+
+    start_times = rand_spiketimes[0::int(num_spikes/num_trials)]
+
+    df['trialStart'] = start_times
+
+    df[event] = df['trialStart'] + np.random.rand(num_trials)
+
+    event_times = ((start_times[:-1] + start_times[1:]) / 2).tolist()
+    event_times.append(start_times[-1] + np.random.rand())
+
+    df[event] = event_times
+
+    df[condition_num] = np.random.rand(num_trials)
+    df[condition_bool] = df[condition_num] < 0.5
+
     all_psth = pop.get_all_psth(event=event, conditions=condition_bool, df=df,
-                                plot=True, binsize=binsize, window=window)
+                                plot=True, binsize=binsize, window=window,
+                                use_parallel=False)
+
+    assert_equal(all_psth['window'], window)
+    assert_equal(all_psth['binsize'], binsize)
+    assert_equal(all_psth['event'], event)
+    assert_equal(all_psth['conditions'], condition_bool)
+
+    for cond_id in all_psth['data'].keys():
+
+        assert_true(cond_id in df[condition_bool])
+        assert_equal(all_psth['data'][cond_id].shape[0],
+                     num_neurons)
+        assert_equal(all_psth['data'][cond_id].shape[1],
+                     (window[1] - window[0]) / binsize)
+
+    assert_raises(ValueError, pop.plot_heat_map, all_psth,
+                  sortby=list(range(num_trials-1)))
+
+    pop.plot_heat_map(all_psth, sortby=list(range(num_trials)))
+    pop.plot_heat_map(all_psth, sortby='rate')
+    pop.plot_heat_map(all_psth, sortby='latency')
+    pop.plot_heat_map(all_psth, sortorder='ascend')
+
+    pop.plot_population_psth(all_psth=all_psth)
+
+def test_popvis_parallel():
+
+    np.random.seed()
+
+    num_spikes = 500
+    num_trials = 10
+
+    binsize = 100
+    window = [-500, 1500]
+
+    num_neurons = 10
+    neuron_list = list()
+
+    for i in range(num_neurons):
+        rand_spiketimes = num_trials * np.random.rand(num_spikes)
+        neuron_list.append(NeuroVis(rand_spiketimes))
+
+    pop = PopVis(neuron_list)
+
+    df = pd.DataFrame()
+
+    event = 'realCueTime'
+    condition_num = 'responseNum'
+    condition_bool = 'responseBool'
+
+    start_times = rand_spiketimes[0::int(num_spikes/num_trials)]
+
+    df['trialStart'] = start_times
+
+    df[event] = df['trialStart'] + np.random.rand(num_trials)
+
+    event_times = ((start_times[:-1] + start_times[1:]) / 2).tolist()
+    event_times.append(start_times[-1] + np.random.rand())
+
+    df[event] = event_times
+
+    df[condition_num] = np.random.rand(num_trials)
+    df[condition_bool] = df[condition_num] < 0.5
+
+    df = pd.DataFrame()
+
+    event = 'anotherRealCueTime'
+    condition_num = 'responseNum'
+    condition_bool = 'responseBool'
+
+    start_times = rand_spiketimes[0::int(num_spikes/num_trials)]
+
+    df['trialStart'] = start_times
+
+    df[event] = df['trialStart'] + np.random.rand(num_trials)
+
+    event_times = ((start_times[:-1] + start_times[1:]) / 2).tolist()
+    event_times.append(start_times[-1] + np.random.rand())
+
+    df[event] = event_times
+
+    df[condition_num] = np.random.rand(num_trials)
+    df[condition_bool] = df[condition_num] < 0.5
+
+    all_psth = pop.get_all_psth(event=event, conditions=condition_bool, df=df,
+                                plot=True, binsize=binsize, window=window,
+                                use_parallel=True)
 
     assert_equal(all_psth['window'], window)
     assert_equal(all_psth['binsize'], binsize)


### PR DESCRIPTION
Single-threaded speedup through JIT histograms and parallelization over neurons. This introduces numba and joblib dependencies, but there is an option to turn off parallelization. If it's turned off, joblib is not imported. -1 option means use all available threads.

On Steinmetz Neuropix dataset, this gets a 3x single-threaded speed increase and theoretically linear speed increase with the number of threads

Tests are passing, except for strf: ` TypeError: object of type <class 'float'> cannot be safely interpreted as an integer.` but I think that's unrelated since this PR does not deal with ML part. Edit: Fixed that test, indeed it wasn't related to this PR. 